### PR TITLE
feat: convert to support new cerebral modules api

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# cerebral-router
+# cerebral-module-router
 An opinionated URL change handler for Cerebral
 
 [![NPM version][npm-image]][npm-url]
@@ -8,7 +8,7 @@ An opinionated URL change handler for Cerebral
 
 ### Install
 
-`npm install cerebral-router`
+`npm install cerebral-module-router`
 
 ### How to use
 
@@ -53,7 +53,7 @@ So let us also add a `homeOpened` signal so that we handle the root url as well.
 
 ```javascript
 
-import Router from 'cerebral-router';
+import Router from 'cerebral-module-router';
 import controller from './controller.js';
 import homeOpened from './signals/homeOpened';
 import messagesOpened from './signals/messagesOpened';
@@ -147,7 +147,7 @@ As you can see it is very powerful.
 
 ### Tell me more about how routes matched
 
-`cerebral-router` relies on [`url-mapper`](https://github.com/cerebral/url-mapper) default behavior:
+`cerebral-module-router` relies on [`url-mapper`](https://github.com/cerebral/url-mapper) default behavior:
 
 * [`path-to-regexp`](https://github.com/pillarjs/path-to-regexp) library is used to define routes and payload parameters.
 It tweaked to preserve payload parameters with `Number` and `Boolean` types, prepending it with colon.
@@ -174,13 +174,13 @@ Then `url-mapper` matches it to route `/messages/:id` and extracts payload `{id:
 
 Feel free to implement [`compileFn`](https://github.com/cerebral/url-mapper/#matcher) which return your own `parse` and `stringify` methods for given route.
 The only recommendation is: parse method for previously stringified payload should result the same payload. Just like `JSON.parse(JSON.stringify(object))`.
-[Create an issue](https://github.com/cerebral/cerebral-router/issues/new) if you need this now since `cerebral-router` had to be patched to support custom mapper.
+[Create an issue](https://github.com/cerebral/cerebral-module-router/issues/new) if you need this now since `cerebral-module-router` had to be patched to support custom mapper.
 
-[npm-image]: https://img.shields.io/npm/v/cerebral-router.svg?style=flat
-[npm-url]: https://npmjs.org/package/cerebral-router
-[travis-image]: https://img.shields.io/travis/cerebral/cerebral-router.svg?style=flat
-[travis-url]: https://travis-ci.org/cerebral/cerebral-router
-[coveralls-image]: https://img.shields.io/coveralls/cerebral/cerebral-router.svg?style=flat
-[coveralls-url]: https://coveralls.io/r/cerebral/cerebral-router?branch=master
-[bithound-image]: https://www.bithound.io/github/cerebral/cerebral-router/badges/score.svg
-[bithound-url]: https://www.bithound.io/github/cerebral/cerebral-router
+[npm-image]: https://img.shields.io/npm/v/cerebral-module-router.svg?style=flat
+[npm-url]: https://npmjs.org/package/cerebral-module-router
+[travis-image]: https://img.shields.io/travis/cerebral/cerebral-module-router.svg?style=flat
+[travis-url]: https://travis-ci.org/cerebral/cerebral-module-router
+[coveralls-image]: https://img.shields.io/coveralls/cerebral/cerebral-module-router.svg?style=flat
+[coveralls-url]: https://coveralls.io/r/cerebral/cerebral-module-router?branch=master
+[bithound-image]: https://www.bithound.io/github/cerebral/cerebral-module-router/badges/score.svg
+[bithound-url]: https://www.bithound.io/github/cerebral/cerebral-module-router

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+var MODULE = 'cerebral-module-router';
+
 var Mapper = require('url-mapper');
 var addressbar;
 try {
@@ -12,8 +14,7 @@ try {
   };
 }
 
-function router (controller, routesConfig, options) {
-
+function Router (routesConfig, options) {
   options = options || {};
 
   if(!routesConfig) {
@@ -28,18 +29,113 @@ function router (controller, routesConfig, options) {
 
   var urlMapper = Mapper(options.mapper);
 
-  // prepare routes for url-mapper
-  // flatten routes and use actual signal for match
-  var routes = Object.keys(routesConfig)
+  function createCallback (controller) {
+    var signals = controller.getSignals();
+
+    // Create url based on direct signal input
+    function getUrl (route, input) {
+      return options.baseUrl + urlMapper.stringify(route.route, input || {});
+    }
+
+    var routes = wrapSignals(routesConfig, signals, getUrl);
+
+    return function onUrlChange (event) {
+      var matchedRoute;
+      var url = event ? event.target.value : addressbar.value;
+      url = url.replace(addressbar.origin, '');
+
+      if (options.onlyHash && !~url.indexOf('#')) {
+        // treat hash absense as root route
+        url = url + '#/';
+      }
+
+      if (controller.getStore().isRemembering()) {
+        return;
+      }
+
+      // check if url should be routed
+      if (url.indexOf(options.baseUrl) === 0) {
+        event && event.preventDefault();
+        matchedRoute = urlMapper.map(url.replace(options.baseUrl, ''), routes);
+
+        if (matchedRoute) {
+          matchedRoute.match(matchedRoute.values);
+        } else {
+          console.warn('Cerebral router - No route matched "' + url + '" url, navigation was prevented. ' +
+                       'Please verify url or catch unmatched routes with a "/*" route.');
+        }
+      }
+    };
+  }
+
+  return function init (module, controller) {
+    var onUrlChange = createCallback(controller);
+    addressbar.on('change', onUrlChange);
+    module.alias(MODULE);
+    module.services({
+      trigger: trigger,
+      redirect: redirect,
+      getUrl: getUrl,
+      detach: detach
+    });
+
+    function trigger (url) {
+      // If developing, remember signals before
+      // route trigger
+      if (controller.getStore().getSignals().length) {
+        controller.getStore().rememberInitial(controller.getStore().getSignals().length - 1);
+      }
+
+      addressbar.value = url || addressbar.value;
+      onUrlChange();
+    };
+
+    function redirect (url, params) {
+      params = params || {};
+      params.replace = (typeof params.replace === "undefined") ? true : params.replace;
+
+      addressbar.value = {
+        value: options.baseUrl + url,
+        replace: params.replace
+      };
+
+      onUrlChange();
+    };
+
+    function getUrl () {
+      return addressbar.value.replace(addressbar.origin + options.baseUrl, '');
+    };
+
+    function detach (){
+      addressbar.removeListener('change', onUrlChange);
+    };
+  };
+}
+
+Router.redirect = function (url, params) {
+  function action (args) {
+    var module = args.modules[MODULE];
+    return module.services.redirect(url, params);
+  }
+
+  action.displayName = 'redirect(' + url + ')';
+
+  return action;
+};
+
+module.exports = Router;
+
+function wrapSignals (routesConfig, signals, getUrl) {
+  // wrap bound signals and return routes map prepared for url-mapper
+  return Object.keys(routesConfig)
     .map(function(route){
       return {
         route: route,
         signalName: routesConfig[route]
       };
     })
-    .reduce(function wrapRoutes(routes, route) {
-
-      // recursive call for nested definition
+    .reduce(function wrapSignal (routes, route) {
+      // recursive call for nested routes definition
       if (typeof route.signalName === 'object') {
         Object.keys(route.signalName).reduce(function(routes, nestedRoute) {
           nestedRoute = {
@@ -47,7 +143,7 @@ function router (controller, routesConfig, options) {
             signalName: route.signalName[nestedRoute]
           };
 
-          return wrapRoutes(routes, nestedRoute);
+          return wrapSignal(routes, nestedRoute);
         }, routes);
 
         return routes;
@@ -55,7 +151,7 @@ function router (controller, routesConfig, options) {
 
       // retrieve actual signal by name
       var signalPath = route.signalName.split('.');
-      var signalParent = controller.getSignals();
+      var signalParent = signals;
       var signal;
       while(signalPath.length - 1) {
         signalParent = signalParent[signalPath.shift()] || {};
@@ -69,24 +165,19 @@ function router (controller, routesConfig, options) {
         throw new Error('Cerebral router - The signal "' + route.signalName + '" has already been bound to route. Create a new signal and reuse actions instead if needed.');
       }
 
-      // Create url based on direct signal input
-      function getUrl (input) {
-        return options.baseUrl + urlMapper.stringify(route.route, input || {});
-      }
-
-      function wrappedSignal(payload, signalOptions) {
-        addressbar.value = getUrl(payload);
-
-        signalOptions = signalOptions || {};
+      function wrappedSignal (payload, signalOptions) {
+        // set addressbar url on signal call
+        addressbar.value = getUrl(route, payload);
 
         // Should always run sync
+        signalOptions = signalOptions || {};
         signalOptions.isSync = true;
         signalOptions.isRouted = true;
         signal(payload, signalOptions);
       }
 
       // expose method for restoring url from params
-      wrappedSignal.getUrl = getUrl;
+      wrappedSignal.getUrl = getUrl.bind(null, route);
 
       // pass wrapped signal to url-mapper routes
       routes[route.route] = wrappedSignal;
@@ -95,90 +186,5 @@ function router (controller, routesConfig, options) {
       signalParent[signalPath[0]] = wrappedSignal.sync = wrappedSignal;
 
       return routes;
-
-  }, {});
-
-  function onUrlChange(event) {
-
-    var matchedRoute;
-    var url = event ? event.target.value : addressbar.value;
-    url = url.replace(addressbar.origin, '');
-
-    if (options.onlyHash && !~url.indexOf('#')) {
-      // treat hash absense as root route
-      url = url + '#/';
-    }
-
-    if (controller.getStore().isRemembering()) {
-      return;
-    }
-
-    // check if url should be routed
-    if (url.indexOf(options.baseUrl) === 0) {
-      event && event.preventDefault();
-      matchedRoute = urlMapper.map(url.replace(options.baseUrl, ''), routes);
-
-      if (matchedRoute) {
-        matchedRoute.match(matchedRoute.values);
-      } else {
-        console.warn('Cerebral router - No route matched "' + url + '" url, navigation was prevented. ' +
-                     'Please verify url or catch unmatched routes with a "/*" route.');
-      }
-    }
-
-  }
-
-  addressbar.on('change', onUrlChange);
-
-  // auto expose router instance to services
-  return controller.getServices().router = {
-    trigger: function (url) {
-
-      // If developing, remember signals before
-      // route trigger
-      if (controller.getStore().getSignals().length) {
-        controller.getStore().rememberInitial(controller.getStore().getSignals().length - 1);
-      }
-
-      addressbar.value = url || addressbar.value;
-      onUrlChange();
-
-    },
-
-    redirect: function(url, params) {
-
-      params = params || {};
-      params.replace = (typeof params.replace === "undefined") ? true : params.replace;
-
-      addressbar.value = {
-        value: options.baseUrl + url,
-        replace: params.replace
-      };
-
-      onUrlChange();
-
-    },
-
-    getUrl: function() {
-      return addressbar.value.replace(addressbar.origin + options.baseUrl, '');
-    },
-
-    detach: function(){
-      addressbar.removeListener('change', onUrlChange);
-    }
-  };
-
+    }, {});
 }
-
-router.redirect = function(url, params) {
-
-  function action(arg) {
-    return arg.services.router.redirect(url, params);
-  }
-
-  action.displayName = 'redirect(' + url + ')';
-
-  return action;
-};
-
-module.exports = router;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "cerebral-router",
-  "version": "0.9.2",
+  "name": "cerebral-module-router",
+  "version": "0.10.0",
   "description": "An opinionated URL change handler for Cerebral",
   "main": "index.js",
   "scripts": {
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/cerebral/cerebral-router.git"
+    "url": "git+https://github.com/cerebral/cerebral-module-router.git"
   },
   "keywords": [
     "router",
@@ -22,9 +22,9 @@
   ],
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/cerebral/cerebral-router/issues"
+    "url": "https://github.com/cerebral/cerebral-module-router/issues"
   },
-  "homepage": "https://github.com/cerebral/cerebral-router#readme",
+  "homepage": "https://github.com/cerebral/cerebral-module-router#readme",
   "dependencies": {
     "addressbar": "^0.4.4",
     "url-mapper": "^0.5.2"

--- a/tests/node.js
+++ b/tests/node.js
@@ -13,22 +13,24 @@ var Model = require('cerebral-model-baobab');
 var Router = require('./../index.js');
 
 module.exports['should work in node.js'] = function(test){
-    var controller = Controller(Model({}));
-    controller.signals({
-      'test': [
-          function checkAction(input) {
-              test.ok(true);
-          }
-      ]
-    });
+  var controller = Controller(Model({}));
+  controller.signals({
+    'test': [function checkAction(input) {
+      test.ok(true);
+    }]
+  });
 
-    var router = Router(controller, {
-        '/test': 'test'
-    });
+  controller.modules({
+    router: Router({
+      '/test': 'test'
+    })
+  });
 
-    router.trigger('/test');
-    router.detach();
+  var router = controller.getServices().router;
 
-    test.expect(1);
-    test.done();
+  router.trigger('/test');
+  router.detach();
+
+  test.expect(1);
+  test.done();
 };


### PR DESCRIPTION
BREAKING CHANGE:
Changed a way to initialize router.
Use new cerebral modules api: `controller.modules({router: Router(routes, options)})`.
Package renamed to conform module naming convention.

closes #59