### PR TITLE
Redirect, run async, remembering, trigger on modulesLoaded event

### DIFF
--- a/index.js
+++ b/index.js
@@ -160,7 +160,8 @@ function getRoutableSignals (config, signals, getUrl) {
     var signal = get(signals, config[route])
     if (!signal) {
       throw new Error('Cerebral router - The signal "' + config[route] +
-      '" for the route "' + route + '" does not exist.')
+      '" for the route "' + route + '" does not exist. ' +
+      'Make sure that ' + MODULE + 'loaded after all modules with routable signals.')
     }
     if (routableSignals[config[route]]) {
       throw new Error('Cerebral router - The signal "' + config[route] +

--- a/index.js
+++ b/index.js
@@ -85,6 +85,10 @@ function Router (routesConfig, options) {
       }
     }
 
+    function onModulesLoaded (event) {
+      setTimeout(onUrlChange)
+    }
+
     var services = {
       trigger: function trigger (url) {
         console.warn('Cerebral router - trigger service method is deprecated.')
@@ -128,6 +132,7 @@ function Router (routesConfig, options) {
     addressbar.on('change', onUrlChange)
     controller.on('signalTrigger', onSignalTrigger)
     controller.on('signalStart', onSignalStart)
+    controller.on('modulesLoaded', onModulesLoaded)
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -109,6 +109,11 @@ function Router (routesConfig, options) {
         }
 
         setTimeout(onUrlChange)
+      },
+
+      redirectToSignal: function redirectToSignal (signalName, payload) {
+        var signal = get(signals, signalName).signal
+        if (signal) setTimeout(signal.bind(null, payload))
       }
     }
 

--- a/index.js
+++ b/index.js
@@ -22,10 +22,13 @@ function Router (routesConfig, options) {
   options = options || {}
 
   if (!routesConfig) {
-    throw new Error("Cerebral router - Routes configuration wasn't provided.")
+    throw new Error('Cerebral router - Routes configuration wasn\'t provided.')
   } else {
     routesConfig = flattenConfig(routesConfig)
   }
+
+  /* istanbul ignore if */
+  if (options.autoTrigger) console.warn('Cerebral router - autoTrigger option can be safely removed.')
 
   if (!options.baseUrl && options.onlyHash) {
     // autodetect baseUrl
@@ -125,8 +128,6 @@ function Router (routesConfig, options) {
     addressbar.on('change', onUrlChange)
     controller.on('signalTrigger', onSignalTrigger)
     controller.on('signalStart', onSignalStart)
-
-    if (options.autoTrigger) services.trigger()
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ function Router (routesConfig, options) {
           replace: params.replace
         }
 
-        onUrlChange()
+        setTimeout(onUrlChange)
       }
     }
 

--- a/index.js
+++ b/index.js
@@ -81,6 +81,7 @@ function Router (routesConfig, options) {
 
     var services = {
       trigger: function trigger (url) {
+        console.warn('Cerebral router - trigger service method is deprecated.')
         addressbar.value = url || addressbar.value
         onUrlChange()
       },

--- a/index.js
+++ b/index.js
@@ -67,7 +67,10 @@ function Router (routesConfig, options) {
 
     function onSignalTrigger (event) {
       var signal = signals[event.signal.name]
-      if (signal) event.signal.isSync = true
+      if (signal) {
+        event.signal.isSync = true
+        event.signal.isRouted = true
+      }
     }
 
     function onSignalStart (event) {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "url-mapper": "^1.0.0"
   },
   "devDependencies": {
-    "cerebral": "^0.33.3",
+    "cerebral": "^0.33.7",
     "cerebral-model-baobab": "^0.4.5",
     "commitizen": "^2.5.0",
     "conventional-changelog": "0.0.17",
@@ -60,6 +60,6 @@
     "validate-commit-msg": "^1.1.1"
   },
   "peerDependencies": {
-    "cerebral": "^0.33.3"
+    "cerebral": "^0.33.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "cerebral-module-router",
+  "version": "0.0.0-semantically-released",
   "description": "An opinionated URL change handler for Cerebral",
   "main": "index.js",
   "scripts": {

--- a/tests/browser.js
+++ b/tests/browser.js
@@ -133,6 +133,25 @@ module.exports = {
     test.done()
   },
 
+  'should set isSync and isRouted flags on signal': function (test) {
+    this.controller.signals({
+      test: [ function () {} ]
+    })
+
+    this.controller.modules({
+      devtools: function () {},
+      router: Router({
+        '/': 'test'
+      })
+    })
+
+    this.controller.once('signalStart', function (args) {
+      test.ok(args.signal.isSync)
+      test.ok(args.signal.isRouted)
+    })
+    test.done()
+  },
+
   'should run nested signal': function (test) {
     this.controller.signals({
       'test.test1.test2': [

--- a/tests/browser.js
+++ b/tests/browser.js
@@ -331,7 +331,7 @@ module.exports = {
     test.done()
   },
 
-  'should replaceState on redirect by default': function (test) {
+  'should provide redirect action factory': function (test) {
     this.controller.signals({
       'existing': [
         function checkAction () { test.ok(true) }
@@ -351,6 +351,27 @@ module.exports = {
     emit('/missing')
 
     test.equals(addressbar.pathname, '/existing')
+    test.done()
+  },
+
+  'should replaceState on redirect by default': function (test) {
+    this.controller.signals({
+      'existing': [
+        function checkAction () { test.ok(true) }
+      ],
+      'noop': []
+    })
+
+    this.controller.modules({
+      devtools: function () {},
+      router: Router({
+        '/existing': 'existing',
+        '/*': 'noop'
+      })
+    })
+
+    this.controller.getServices().router.redirect('/existing')
+    test.equals(addressbar.pathname, '/existing')
     test.equals(window.location.lastChangedWith, 'replaceState')
     test.done()
   },
@@ -360,20 +381,18 @@ module.exports = {
       'existing': [
         function checkAction () { test.ok(true) }
       ],
-      'missing': [
-        redirect('/existing', {replace: false})
-      ]
+      'noop': []
     })
 
     this.controller.modules({
       devtools: function () {},
       router: Router({
         '/existing': 'existing',
-        '/*': 'missing'
+        '/*': 'noop'
       })
     })
-    emit('/missing')
 
+    this.controller.getServices().router.redirect('/existing', { replace: false })
     test.equals(addressbar.pathname, '/existing')
     test.equals(window.location.lastChangedWith, 'pushState')
     test.done()

--- a/tests/browser.js
+++ b/tests/browser.js
@@ -271,22 +271,6 @@ module.exports = {
     test.done()
   },
 
-  'should preserve sync method for wrapped signal': function (test) {
-    var controller = this.controller
-
-    this.createRouteTest({
-      route: '/:param'
-    })
-
-    test.doesNotThrow(function () {
-      controller.getSignals().match.sync({ param: 'test' })
-    })
-    test.throws(function () {
-      controller.getSignals().match.sync()
-    })
-    test.done()
-  },
-
   'should expose `getUrl` method on router service': function (test) {
     this.createRouteTest({
       route: '/:param',
@@ -326,20 +310,6 @@ module.exports = {
     })
 
     test.equals(this.controller.getSignals().match.getUrl({ param: 'test' }), '/test#/test')
-    test.done()
-  },
-
-  'should expose original `chains` for wrapped signal': function (test) {
-    this.createRouteTest({
-      route: '/:param',
-      options: {
-        baseUrl: '/test',
-        onlyHash: true
-      }
-    })
-
-    test.equals(typeof this.controller.getSignals().match.chain[0], 'function')
-    test.equals(this.controller.getSignals().match.chain[0].name, 'setMatch')
     test.done()
   },
 

--- a/tests/browser.js
+++ b/tests/browser.js
@@ -360,9 +360,14 @@ module.exports = {
   },
 
   'should replaceState on redirect by default': function (test) {
+    test.expect(2)
     this.controller.signals({
       'existing': [
-        function checkAction () { test.ok(true) }
+        function checkAction () {
+          test.equals(addressbar.pathname, '/existing')
+          test.equals(window.location.lastChangedWith, 'replaceState')
+          test.done()
+        }
       ],
       'missing': [
         redirect('/existing')
@@ -377,16 +382,17 @@ module.exports = {
       })
     })
     this.controller.getServices().router.trigger()
-
-    test.equals(addressbar.pathname, '/existing')
-    test.equals(window.location.lastChangedWith, 'replaceState')
-    test.done()
   },
 
   'should allow pushState on redirect': function (test) {
+    test.expect(2)
     this.controller.signals({
       'existing': [
-        function checkAction () { test.ok(true) }
+        function checkAction () {
+          test.equals(addressbar.pathname, '/existing')
+          test.equals(window.location.lastChangedWith, 'pushState')
+          test.done()
+        }
       ],
       'missing': [
         redirect('/existing', {replace: false})
@@ -401,10 +407,6 @@ module.exports = {
       })
     })
     this.controller.getServices().router.trigger()
-
-    test.equals(addressbar.pathname, '/existing')
-    test.equals(window.location.lastChangedWith, 'pushState')
-    test.done()
   },
 
   'should warn if navigation prevented': function (test) {

--- a/tests/browser.js
+++ b/tests/browser.js
@@ -133,6 +133,23 @@ module.exports = {
     test.done()
   },
 
+  'should trigger on modulesLoaded': function (test) {
+    this.controller.signals({
+      test: [
+        function checkAction () {
+          test.done()
+        }
+      ]
+    })
+
+    this.controller.modules({
+      devtools: function () {},
+      router: Router({
+        '/': 'test'
+      })
+    })
+  },
+
   'should set isSync and isRouted flags on signal': function (test) {
     this.controller.signals({
       test: [ function () {} ]

--- a/tests/browser.js
+++ b/tests/browser.js
@@ -398,6 +398,27 @@ module.exports = {
     test.done()
   },
 
+  'should run redirect async': function (test) {
+    test.expect(0)
+    this.controller.signals({
+      'noop': [],
+      'existing': [
+        function checkAction () { test.ok(true) }
+      ]
+    })
+
+    this.controller.modules({
+      devtools: function () {},
+      router: Router({
+        '/existing': 'existing',
+        '/*': 'noop'
+      })
+    })
+
+    this.controller.getServices().router.redirect('/existing')
+    test.done()
+  },
+
   'should warn if navigation prevented': function (test) {
     var routeTest = this.createRouteTest({
       route: '/',

--- a/tests/browser.js
+++ b/tests/browser.js
@@ -25,6 +25,13 @@ var addressbar = require('addressbar')
 var Router = require('./../index.js')
 var redirect = Router.redirect
 
+function emit (url) {
+  addressbar.emit('change', {
+    preventDefault: function () {},
+    target: {value: addressbar.origin + url}
+  })
+}
+
 // TESTS
 module.exports = {
   setUp: function (cb) {
@@ -116,8 +123,8 @@ module.exports = {
         '/': 'test'
       })
     })
-    // sync run on trigger
-    this.controller.getServices().router.trigger()
+    // sync run on emit
+    emit('/')
 
     // sync run after wrapping
     this.controller.getSignals().test()
@@ -139,7 +146,7 @@ module.exports = {
         '/': 'test.test1.test2'
       })
     })
-    this.controller.getServices().router.trigger()
+    emit('/')
 
     test.expect(1)
     test.done()
@@ -167,14 +174,9 @@ module.exports = {
       })
     })
 
-    addressbar.value = '/foo'
-    this.controller.getServices().router.trigger()
-
-    addressbar.value = '/foo/bar'
-    this.controller.getServices().router.trigger()
-
-    addressbar.value = '/foo/baz'
-    this.controller.getServices().router.trigger()
+    emit('/foo')
+    emit('/foo/bar')
+    emit('/foo/baz')
 
     test.expect(3)
     test.done()
@@ -360,14 +362,9 @@ module.exports = {
   },
 
   'should replaceState on redirect by default': function (test) {
-    test.expect(2)
     this.controller.signals({
       'existing': [
-        function checkAction () {
-          test.equals(addressbar.pathname, '/existing')
-          test.equals(window.location.lastChangedWith, 'replaceState')
-          test.done()
-        }
+        function checkAction () { test.ok(true) }
       ],
       'missing': [
         redirect('/existing')
@@ -381,18 +378,17 @@ module.exports = {
         '/*': 'missing'
       })
     })
-    this.controller.getServices().router.trigger()
+    emit('/missing')
+
+    test.equals(addressbar.pathname, '/existing')
+    test.equals(window.location.lastChangedWith, 'replaceState')
+    test.done()
   },
 
   'should allow pushState on redirect': function (test) {
-    test.expect(2)
     this.controller.signals({
       'existing': [
-        function checkAction () {
-          test.equals(addressbar.pathname, '/existing')
-          test.equals(window.location.lastChangedWith, 'pushState')
-          test.done()
-        }
+        function checkAction () { test.ok(true) }
       ],
       'missing': [
         redirect('/existing', {replace: false})
@@ -406,7 +402,11 @@ module.exports = {
         '/*': 'missing'
       })
     })
-    this.controller.getServices().router.trigger()
+    emit('/missing')
+
+    test.equals(addressbar.pathname, '/existing')
+    test.equals(window.location.lastChangedWith, 'pushState')
+    test.done()
   },
 
   'should warn if navigation prevented': function (test) {

--- a/tests/browser.js
+++ b/tests/browser.js
@@ -419,6 +419,59 @@ module.exports = {
     test.done()
   },
 
+  'should allow redirect to signal': function (test) {
+    test.expect(2)
+    this.controller.signals({
+      'home': [],
+      'createClicked': [
+        function createEntity (args) {
+          var entityId = 42
+          args.services.router.redirectToSignal('detail', { id: entityId })
+        }
+      ],
+      'detail': [
+        function checkAction (args) {
+          test.equal(args.input.id, 42)
+          test.equal(addressbar.pathname, '/%3A42')
+          test.done()
+        }
+      ]
+    })
+
+    this.controller.modules({
+      devtools: function () {},
+      router: Router({
+        '/': 'home',
+        '/:id': 'detail'
+      })
+    })
+
+    this.controller.getSignals().createClicked()
+  },
+
+  'should run redirectToSignal async': function (test) {
+    test.expect(0)
+    this.controller.signals({
+      'noop': [],
+      'test': [
+        function (args) {
+          test.ok(true)
+        }
+      ]
+    })
+
+    this.controller.modules({
+      devtools: function () {},
+      router: Router({
+        '/': 'noop',
+        '/test': 'test'
+      })
+    })
+
+    this.controller.getServices().router.redirectToSignal('test')
+    test.done()
+  },
+
   'should warn if navigation prevented': function (test) {
     var routeTest = this.createRouteTest({
       route: '/',

--- a/tests/browser.js
+++ b/tests/browser.js
@@ -201,26 +201,6 @@ module.exports = {
     test.done()
   },
 
-  'should trigger with autoTrigger option': function (test) {
-    this.controller.signals({
-      test: [
-        function checkAction () { test.ok(true) }
-      ]
-    })
-
-    this.controller.modules({
-      devtools: function () {},
-      router: Router({
-        '/': 'test'
-      }, {
-        autoTrigger: true
-      })
-    })
-
-    test.expect(1)
-    test.done()
-  },
-
   'should throw on missing routes': function (test) {
     test.throws(function () {
       Router()

--- a/tests/browser.js
+++ b/tests/browser.js
@@ -150,6 +150,37 @@ module.exports = {
     })
   },
 
+  'should not trigger on modulesLoaded if url was remembered': function (test) {
+    test.expect(1)
+    var controller = this.controller
+
+    this.controller.signals({
+      foo: [
+        function checkAction () { test.ok(true) }
+      ],
+      bar: [
+        function checkAction () { test.ok(true) }
+      ]
+    })
+
+    this.controller.on('modulesLoaded', function () {
+      setTimeout(function () {
+        test.equals(addressbar.pathname, '/foo')
+        test.done()
+      })
+    })
+
+    this.controller.modules({
+      router: Router({
+        '/foo': 'foo',
+        '/bar': 'bar'
+      }),
+      devtools: function () {
+        controller.emit('predefinedSignal', { signal: { name: 'foo' } })
+      }
+    })
+  },
+
   'should set isSync and isRouted flags on signal': function (test) {
     this.controller.signals({
       test: [ function () {} ]


### PR DESCRIPTION
32dc841 feat: remember url from predefined signal run
42338ba feat: auto trigger on modulesLoaded event
e94664c feat(autoTrigger): remove autoTrigger option
296135a chore(package): package version placeholder
025b4a2 fix: indicate that signal isRouted for debugger
5d5dba7 feat(config): suggest to check modules loading order in case of absent signal
f602252 feat: introduce redirectToSignal service
f490b6c feat(redirect): async run to allow current signal to finish before trigger redirected one
02c00a8 test(redirect): call redirect service directly
5feaf64 test: remove redandant tests since signals not wrapped anymore
6b64436 feat: deprecate service `trigger` method
d54aa86 test: emulate emit on addressbar to trigger signals instead of trigger service method
ca8e9b1 test(redirect): make sure that signal bound to redirected url is triggered