### PR TITLE
remove setting isSync flag for signals

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,13 +85,6 @@ function Router (routesConfig, options) {
       }
     }
 
-    function onSignalTrigger (event) {
-      var signal = signals[event.signal.name]
-      if (signal) {
-        event.signal.isSync = true
-      }
-    }
-
     function onSignalStart (event) {
       if (Array.isArray(initialSignals)) {
         initialSignals.push(event.signal)
@@ -174,7 +167,6 @@ function Router (routesConfig, options) {
     module.addServices(services)
     addressbar.on('change', onUrlChange)
     controller.on('predefinedSignal', onPredefinedSignal)
-    controller.on('signalTrigger', onSignalTrigger)
     controller.on('signalStart', onSignalStart)
 
     if (!options.preventAutostart) {

--- a/index.js
+++ b/index.js
@@ -34,13 +34,8 @@ function Router (routesConfig, options) {
   options.baseUrl = (options.baseUrl || '') + (options.onlyHash ? '#' : '')
   var urlMapper = Mapper(options.mapper)
 
-  function _getUrl (route, input) {
-    console.warn('Cerebral router - signal.getUrl() method is deprecated. Use service method getSignalUrl() instead')
-    return options.baseUrl + urlMapper.stringify(route, input || {})
-  }
-
   return function init (module, controller) {
-    var signals = getRoutableSignals(routesConfig, controller.getSignals(), _getUrl)
+    var signals = getRoutableSignals(routesConfig, controller.getSignals())
     var rememberedUrl
     var initialSignals
 
@@ -216,7 +211,7 @@ function flattenConfig (config, prev, flatten) {
   return flatten
 }
 
-function getRoutableSignals (config, signals, getUrl) {
+function getRoutableSignals (config, signals) {
   var routableSignals = {}
 
   Object.keys(config).forEach(function (route) {
@@ -231,7 +226,6 @@ function getRoutableSignals (config, signals, getUrl) {
       '" has already been bound to route "' + route +
       '". Create a new signal and reuse actions instead if needed.')
     }
-    signal.getUrl = getUrl.bind(null, route)
     routableSignals[config[route]] = {
       route: route,
       signal: signal

--- a/index.js
+++ b/index.js
@@ -27,8 +27,6 @@ function Router (routesConfig, options) {
     routesConfig = flattenConfig(routesConfig)
   }
 
-  if (options.autoTrigger) console.warn('Cerebral router - autoTrigger option can be safely removed.')
-
   if (!options.baseUrl && options.onlyHash) {
     // autodetect baseUrl
     options.baseUrl = addressbar.pathname

--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
     "commitizen": {
       "path": "node_modules/cz-customizable"
     },
+    "cz-customizable": {
+      "config": "node_modules/cz-customizable/cz-config-EXAMPLE.js"
+    },
     "ghooks": {
       "commit-msg": "validate-commit-msg"
     }
@@ -40,26 +43,26 @@
     "analyzeCommits": "./sr-prerelease.js"
   },
   "dependencies": {
-    "addressbar": "^1.0.1",
-    "lodash.get": "^4.0.1",
+    "addressbar": "^1.0.2",
+    "lodash.get": "^4.2.0",
     "lodash.isobject": "^3.0.2",
-    "url-mapper": "^1.0.0"
+    "url-mapper": "^1.1.0"
   },
   "devDependencies": {
-    "cerebral": "^0.33.8",
-    "cerebral-model-baobab": "^0.4.7",
-    "commitizen": "^2.5.0",
+    "cerebral": "^0.33.31",
+    "cerebral-model-baobab": "^0.4.8",
+    "commitizen": "^2.7.6",
     "conventional-changelog": "0.0.17",
-    "coveralls": "^2.11.6",
-    "cz-customizable": "^2.7.0",
-    "ghooks": "^1.0.3",
-    "istanbul": "^0.4.2",
+    "coveralls": "^2.11.9",
+    "cz-customizable": "^3.1.0",
+    "ghooks": "^1.2.0",
+    "istanbul": "^0.4.3",
     "nodeunit": "^0.9.1",
     "semantic-release": "^4.3.5",
-    "standard": "^6.0.4",
-    "validate-commit-msg": "^2.0.0"
+    "standard": "^6.0.8",
+    "validate-commit-msg": "^2.5.0"
   },
   "peerDependencies": {
-    "cerebral": "^0.33.8"
+    "cerebral": "^0.33.31"
   }
 }

--- a/tests/browser.js
+++ b/tests/browser.js
@@ -483,15 +483,6 @@ module.exports = {
     test.done()
   },
 
-  'should inform that `autoTrigger` could be removed': function (test) {
-    Router({}, {
-      autoTrigger: true
-    })
-
-    test.equal(this.warnMessage.length >= 0, true)
-    test.done()
-  },
-
   'should expose `getUrl` method on router service': function (test) {
     this.createRouteTest({
       route: '/:param',

--- a/tests/browser.js
+++ b/tests/browser.js
@@ -531,22 +531,6 @@ module.exports = {
     test.done()
   },
 
-  'should warn `getUrl` method for wrapped signal is deprecated': function (test) {
-    this.createRouteTest({
-      route: '/',
-      options: {
-        baseUrl: '/test',
-        mapper: { query: true },
-        onlyHash: true
-      }
-    })
-
-    test.equals(this.controller.getSignals().match.getUrl(), '/test#/')
-    test.equals(this.controller.getSignals().match.getUrl({ param: 'test' }), '/test#/?param=test')
-    test.equal(this.warnMessage.indexOf('deprecated') >= 0, true)
-    test.done()
-  },
-
   'should update addressbar for routable signal call': function (test) {
     this.createRouteTest({
       route: '/test',

--- a/tests/browser.js
+++ b/tests/browser.js
@@ -3,7 +3,8 @@ global.window = {
   location: {
     origin: 'http://localhost:3000',
     href: 'http://localhost:3000/initial'
-  }
+  },
+  history: {}
 }
 global.history = {
   pushState: function (_, __, value) {
@@ -98,6 +99,9 @@ module.exports = {
     this.warn = console.warn
     console.warn = function (message) {
       this.warnMessage = message
+      if (!~message.indexOf('Cerebral router')) {
+        this.warn(message)
+      }
     }.bind(this)
 
     cb()

--- a/tests/browser.js
+++ b/tests/browser.js
@@ -189,8 +189,8 @@ module.exports = {
       devtools: function () {},
       app: function (modules, controller) {
         controller.on('modulesLoaded', function () {
-          controller.getSignals().init1({}, { isSync: true })
-          controller.getSignals().init2({}, { isSync: true })
+          controller.getSignals().init1({}, { immediate: true })
+          controller.getSignals().init2({}, { immediate: true })
         })
       },
       router: Router({
@@ -310,7 +310,7 @@ module.exports = {
       },
       app: function (modules, controller) {
         controller.on('modulesLoaded', function () {
-          controller.getSignals().init1({}, { isSync: true })
+          controller.getSignals().init1({}, { immediate: true })
         })
       },
       router: Router({
@@ -562,9 +562,7 @@ module.exports = {
       initialUrl: '/initial'
     })
 
-    this.controller.getSignals().match({}, {
-      isSync: true
-    })
+    this.controller.getSignals().match({}, { immediate: true })
 
     test.equals(addressbar.pathname, '/test')
     test.done()
@@ -595,7 +593,7 @@ module.exports = {
       initialUrl: '/initial'
     })
 
-    this.controller.getSignals().test.sync()
+    this.controller.getSignals().test({}, { immediate: true })
 
     test.equals(addressbar.pathname, '/initial')
     test.done()

--- a/tests/node.js
+++ b/tests/node.js
@@ -15,9 +15,10 @@ var Router = require('./../index.js')
 module.exports['should work in node.js'] = function (test) {
   var controller = Controller(Model({}))
   controller.addSignals({
-    'test': [
-      function checkAction (input) { test.ok(true) }
-    ]
+    'test': {
+      chain: [ function checkAction (input) { test.ok(true) } ],
+      immediate: true
+    }
   })
 
   controller.addModules({


### PR DESCRIPTION
please try `npm i cerebral/cerebral-module-router#remove-isSync` on your projects and leave feedback here.
Known issue: debugger didn't show `routed` flag, but shows `frame`