### PR TITLE
fix(init): should run initial signal immediately

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ function Router (routesConfig, options) {
         if (!rememberedUrl) setTimeout(setRememberedUrl)
 
         var route = signal.route
-        var input = event.signal.input || {}
+        var input = event.signal.input || event.payload || {}
         rememberedUrl = options.baseUrl + urlMapper.stringify(route, input)
       }
     }

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ function Router (routesConfig, options) {
       rememberedUrl = null
     }
 
-    function onUrlChange (event) {
+    function onUrlChange (event, forceImmediate) {
       var url = event ? event.target.value : addressbar.value
       url = url.replace(addressbar.origin, '')
 
@@ -61,9 +61,16 @@ function Router (routesConfig, options) {
           event && event.preventDefault()
           addressbar.value = url
 
-          signals[map.match].signal(map.values, {
-            isRouted: true
-          })
+          if (forceImmediate === true) {
+            signals[map.match].signal(map.values, {
+              isRouted: true,
+              immediate: true
+            })
+          } else {
+            signals[map.match].signal(map.values, {
+              isRouted: true
+            })
+          }
         } else {
           if (options.allowEscape) return
 
@@ -113,8 +120,8 @@ function Router (routesConfig, options) {
     function onModulesLoaded (event) {
       if (rememberedUrl) return
       if (Array.isArray(initialSignals) && initialSignals.length === 0) {
-        setTimeout(onUrlChange)
         initialSignals = null
+        onUrlChange(null, true)
       }
     }
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "pretest": "standard",
-    "test": "nodeunit tests && npm i cerebral@^0.34.0-rc.5 && nodeunit tests",
+    "test": "nodeunit tests && npm i cerebral@^0.34.0 && nodeunit tests",
     "posttest": "npm i",
     "coverage": "nyc --reporter=lcov --reporter=text npm run test",
     "postcoverage": "cat ./coverage/lcov.info | coveralls",
@@ -64,7 +64,7 @@
     "validate-commit-msg": "^2.5.0"
   },
   "peerDependencies": {
-    "cerebral": "^0.33.31 || ^0.34.0-0"
+    "cerebral": "^0.33.31 || ^0.34.0"
   },
   "nyc": {
     "exclude": [

--- a/tests/browser.js
+++ b/tests/browser.js
@@ -224,14 +224,64 @@ module.exports = {
     this.controller.getSignals().test()
   },
 
-  'should not trigger on modulesLoaded if url was remembered': function (test) {
+  'should restore url if remembering occured cerebral@0.33': function (test) {
     test.expect(1)
     var controller = this.controller
 
     controller.addSignals({
-      foo: [ function checkAction () { test.ok(true) } ],
-      bar: [ function checkAction () { test.ok(true) } ],
-      baz: [ function checkAction () { test.ok(true) } ]
+      foo: [ function checkAction () { test.ok(false) } ]
+    })
+
+    controller.on('modulesLoaded', function () {
+      setTimeout(function () {
+        test.equals(addressbar.value.replace(addressbar.origin, ''), '/foo/bar?baz=baz')
+        test.done()
+      })
+    })
+
+    controller.addModules({
+      router: Router({
+        '/foo/:bar': 'foo'
+      }, { mapper: { query: true } }),
+      devtools: function () {
+        controller.emit('predefinedSignal', { signal: { name: 'foo', input: { bar: 'bar', baz: 'baz' } } })
+      }
+    })
+  },
+
+  'should restore url if remembering occured cerebral@0.34': function (test) {
+    test.expect(1)
+    var controller = this.controller
+
+    controller.addSignals({
+      foo: [ function checkAction () { test.ok(false) } ]
+    })
+
+    controller.on('modulesLoaded', function () {
+      setTimeout(function () {
+        test.equals(addressbar.value.replace(addressbar.origin, ''), '/foo/bar?baz=baz')
+        test.done()
+      })
+    })
+
+    controller.addModules({
+      router: Router({
+        '/foo/:bar': 'foo'
+      }, { mapper: { query: true } }),
+      devtools: function () {
+        controller.emit('predefinedSignal', { signal: { name: 'foo' }, payload: { bar: 'bar', baz: 'baz' } })
+      }
+    })
+  },
+
+  'should not run initial trigger on modulesLoaded if there was remembering': function (test) {
+    test.expect(1)
+    var controller = this.controller
+
+    controller.addSignals({
+      foo: [ function checkAction () { test.ok(false) } ],
+      bar: [ function checkAction () { test.ok(false) } ],
+      baz: [ function checkAction () { test.ok(false) } ]
     })
 
     controller.on('modulesLoaded', function () {
@@ -248,22 +298,23 @@ module.exports = {
       }),
       devtools: function () {
         controller.emit('predefinedSignal', { signal: { name: 'foo' } })
-        controller.emit('predefinedSignal', { signal: { name: 'baz' } })
         controller.emit('predefinedSignal', { signal: { name: 'bar' } })
+        controller.emit('predefinedSignal', { signal: { name: 'baz' } })
       }
     })
   },
 
-  'should not run delayed trigger if url was remembered': function (test) {
-    test.expect(1)
+  'should not run delayed initial trigger if there was remembering': function (test) {
+    test.expect(2)
     var controller = this.controller
 
     controller.addSignals({
-      test: [ function checkAction () { test.ok(true) } ],
-      foo: [ function checkAction () { test.ok(true) } ],
+      test: [ function checkAction () { test.ok(false) } ],
+      foo: [ function checkAction () { test.ok(false) } ],
       init1: [
         [ function asyncAction (args) {
           setTimeout(function () {
+            test.ok(true)
             args.output()
           }, 50)
         } ]

--- a/tests/browser.js
+++ b/tests/browser.js
@@ -118,9 +118,11 @@ module.exports = {
     cb()
   },
 
-  'should trigger on modulesLoaded': function (test) {
+  'should trigger sync with modulesLoaded event and run signal immediate': function (test) {
+    test.expect(1)
+
     this.controller.addSignals({
-      test: [ function checkAction () { test.done() } ]
+      test: [ function checkAction () { test.ok(true) } ]
     })
 
     this.controller.addModules({
@@ -129,6 +131,8 @@ module.exports = {
         '/': 'test'
       })
     })
+
+    test.done()
   },
 
   'should delay auto trigger if there is running signals': function (test) {


### PR DESCRIPTION
The router currently runs the initial signal on `setTimeout`. This does not allow signal that prepares some state to do so before the UI is actually rendered... causing a "hickup" of the UI.

This fix removes `setTimeout` on initial router signal. It has been tested on a single project. And tests still runs green after removing it.