### PR TITLE
feat: only warn on missing config

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,8 @@ function Router (routesConfig, options) {
   options = options || {}
 
   if (!routesConfig) {
-    throw new Error('Cerebral router - Routes configuration wasn\'t provided.')
+    console.warn('Cerebral router - Routes configuration wasn\'t provided.')
+    return function () {}
   } else {
     routesConfig = flattenConfig(routesConfig)
   }

--- a/tests/browser.js
+++ b/tests/browser.js
@@ -444,11 +444,12 @@ module.exports = {
     test.done()
   },
 
-  'should throw on missing routes': function (test) {
-    test.throws(function () {
+  'should warn on missing routes': function (test) {
+    test.doesNotThrow(function () {
       Router()
     })
 
+    test.equal(this.warnMessage.length >= 0, true)
     test.done()
   },
 


### PR DESCRIPTION
returns empty module in case of absent config