### PR TITLE
Fix issue with router not handling queries in at root path

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -51,7 +51,7 @@ function Router (routesConfig, options) {
 
       if (options.onlyHash && !~url.indexOf('#')) {
         // treat hash absense as root route
-        url = url + '#/'
+        url = addressbar.pathname + '#/' + new URL(location.href).search
       }
 
       // check if url should be routed


### PR DESCRIPTION
Currently if there is a query add the the base route (ie. '/?isBase=true')

If onlyHash is set to true then currently the path gets altered to be "/?isBase=true#/" instead of "/#/?isBase=true"

The search param is not on addressbar but probably should be added to it keep it in line with the rest of the file. Hence the use of "new URL(location.href).search"